### PR TITLE
Update Travis CI badge to use .com instead of .org

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ for building a Todo List in Phoenix.<br/>
 100% functional. 0% JavaScript. Just `HTML`, `CSS` and `Elixir`.
 Fast and maintainable.
 
-[![Build Status](https://img.shields.io/travis/dwyl/phoenix-todo-list-tutorial/master.svg?style=flat-square)](https://travis-ci.org/dwyl/phoenix-todo-list-tutorial)
+[![Build Status](https://img.shields.io/travis/com/dwyl/phoenix-todo-list-tutorial/master.svg?style=flat-square)](https://travis-ci.com/github/dwyl/phoenix-todo-list-tutorial)
 [![codecov.io](https://img.shields.io/codecov/c/github/dwyl/phoenix-todo-list-tutorial/master.svg?style=flat-square)](http://codecov.io/github/dwyl/phoenix-todo-list-tutorial?branch=master)
 [![HitCount](http://hits.dwyl.com/dwyl/phoenix-todo-list-tutorial.svg)](http://hits.dwyl.com/dwyl/phoenix-todo-list-tutorial)
 [![contributions welcome](https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=flat-square)](https://github.com/dwyl/phoenix-todo-list-tutorial/issues)


### PR DESCRIPTION
@SimonLab this is a micro-update to fix the broken badge in the `README.md`
from: [![Build Status](https://img.shields.io/travis/dwyl/phoenix-todo-list-tutorial/master.svg?style=flat-square)](https://travis-ci.org/dwyl/phoenix-todo-list-tutorial)
```md
[![Build Status](https://img.shields.io/travis/dwyl/phoenix-todo-list-tutorial/master.svg?style=flat-square)](https://travis-ci.org/dwyl/phoenix-todo-list-tutorial)
```

to: [![Build Status](https://img.shields.io/travis/com/dwyl/phoenix-todo-list-tutorial/master.svg?style=flat-square)](https://travis-ci.com/github/dwyl/phoenix-todo-list-tutorial)

```md
[![Build Status](https://img.shields.io/travis/com/dwyl/phoenix-todo-list-tutorial/master.svg?style=flat-square)](https://travis-ci.com/github/dwyl/phoenix-todo-list-tutorial)
```

It's the _first_ thing people see when they open the repo.
so I think it makes sense to fix it. 
😉 
